### PR TITLE
Fix escaping issues when generating the OCI image config files

### DIFF
--- a/sloci-image
+++ b/sloci-image
@@ -269,13 +269,13 @@ oci_image_config() {
 	  "architecture": "$(oci_arch $CFG_ARCH)",
 	  "os": "$CFG_OS",
 	  "config": {
-	    ${CFG_USER:+"\"User\": $(json_string "$CFG_USER"),"}
+	    ${CFG_USER:+"$(echo \"User\"): $(json_string "$CFG_USER"),"}
 	    "ExposedPorts": $(json_pseudoarray "$CFG_PORTS"),
 	    "Env": $(json_string_array "$CFG_ENV"),
 	    "Entrypoint": $(json_string_array "$CFG_ENTRYPOINT"),
 	    "Cmd": $(json_string_array "$CFG_CMD"),
 	    "Volumes": $(json_pseudoarray "$CFG_VOLUMES"),
-	    ${CFG_WORKING_DIR:+"\"WorkingDir\": $(json_string "$CFG_WORKING_DIR"),"}
+	    ${CFG_WORKING_DIR:+"$(echo \"WorkingDir\"): $(json_string "$CFG_WORKING_DIR"),"}
 	    "Labels": $(json_string_map "$CFG_LABELS")
 	  },
 	  "rootfs": {
@@ -309,7 +309,7 @@ oci_image_index() {
 	      "digest": "$manifest_digest",
 	      "platform": {
 	        "architecture": "$(oci_arch $CFG_ARCH)",
-	        ${CFG_ARCH_VARIANT:+"\"variant\": $(json_string "$CFG_ARCH_VARIANT"),"}
+	        ${CFG_ARCH_VARIANT:+"$(echo \"variant\"): $(json_string "$CFG_ARCH_VARIANT"),"}
 	        "os": "$CFG_OS"
 	      },
 	      "annotations": {


### PR DESCRIPTION
Some parameters are not escaping correctly the double quotes when generating the OCI image config files.

This is easily reproducible:

```
$ mkdir rootfs
$ ./sloci-image --arch arm --user 0 rootfs oci-image:latest
$ grep -R "User" oci-image/
oci-image/blobs/sha256/e574ac66b91453b00beb37717ed0e604249fa695ec772e17a56ff208357ec72a:    \"User\": "0",
```

Fix that by escaping the double quotes with an echo command.

Signed-off-by: Sergio Prado <sergio.prado@e-labworks.com>