### PR TITLE
create OCI tar from the contents of working folder

### DIFF
--- a/sloci-image
+++ b/sloci-image
@@ -425,6 +425,6 @@ if [ "$OUT_TYPE" = tar ]; then
 	file_name="$IMAGE_NAME-$CFG_REF_NAME-$CFG_ARCH"
 	file_name="$file_name${CFG_ARCH_VARIANT:+"-$CFG_ARCH_VARIANT"}-$CFG_OS.oci-image"
 
-	tar ${DEBUG:+-v} -cf "$file_name.tar" "$IMAGE_NAME"
+	tar ${DEBUG:+-v} -cf "$file_name.tar" -C "$IMAGE_NAME" .
 	rm -Rf "$IMAGE_NAME"
 fi


### PR DESCRIPTION
When testing with containerd, it was found that the tarfile
created with sloci can't import because the contents are inside
a folder.  Looking around online, it seems that the an oci tar
should container the blob/index.json/oci-layout in the . of the
tarfile.

https://snyk.io/blog/container-image-formats/
https://github.com/opencontainers/image-spec/blob/main/image-layout.md

Signed-off-by: Matthew Weber <matthew.weber@collins.com>