### PR TITLE
oci_arch: fix "--arch arm64" argument

### DIFF
--- a/sloci-image
+++ b/sloci-image
@@ -214,7 +214,7 @@ oci_arch() {
 	case "$1" in
 		x86_64) echo amd64;;
 		x86) echo 386;;
-		aarch64) echo arm64;;
+		aarch64 | arm64) echo arm64;;
 		arm*) echo arm;;
 		*) echo "$1";;
 	esac


### PR DESCRIPTION
The --arch argument presumably should take the appropriate GOARCH-type
string. The oci_arch() function does some conversion on it, which is
needed because without --arch the architecture is taken from "uname -m",
which yields something different than a GOARCH-type string.

However, oci_arch() converts arm* into arm, which is wrong for arm64.
Since arm64 is a proper GOARCH-type string, it shouldn't be converted at
all.

Upate the case statement to convert arm64 to arm64 (i.e., do nothing).
Since the arm64 match comes before arm*, it takes precedence.

Signed-off-by: Arnout Vandecappelle (Essensium/Mind) <arnout@mind.be>